### PR TITLE
[PR] 마이페이지 및 토큰 전달 시 헤더 정보 추가

### DIFF
--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/config/WebConfig.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/config/WebConfig.java
@@ -22,6 +22,7 @@ public class WebConfig implements WebMvcConfigurer {
                         /* 설명. kubernetes 환경에서 프론트의 워커노드는 30000번이고 백엔드 입장에서는 프론트의 워커노드를 CORS 처리 해 주어야 한다. */
 //                        "http://localhost:30000"
                 )
+                .allowCredentials(true)
                 .allowedMethods("GET", "POST", "PUT", "DELETE");
     }
 }

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/aggregate/Member.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/aggregate/Member.java
@@ -24,6 +24,8 @@ public class Member {
     @Column
     private String profile;
     @Column
+    private String image;
+    @Column
     @CreationTimestamp
     private String signUpDate;
     @Column(name = "IS_WITHDRAW")

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/controller/AuthController.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/controller/AuthController.java
@@ -3,10 +3,7 @@ package org.omoknoone.onionhotsayyo.member.controller;
 import org.omoknoone.onionhotsayyo.member.service.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.naming.AuthenticationException;
 

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/controller/MemberController.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/controller/MemberController.java
@@ -79,6 +79,23 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @GetMapping("/mypage/{memberId}")
+    public ResponseEntity<ResponseMessage> mypage(@PathVariable String memberId) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+
+        ResponseMember responseMember = modelMapper.map(memberService.getMemberDetailsByMemberId(memberId), ResponseMember.class);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("result", responseMember);
+
+        return ResponseEntity
+                .ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "마이페이지 로딩 성공", responseMap));
+    }
+
     @GetMapping("/health_check")
     public String healthCheck() {
         return "Good";

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/AuthenticationFilter.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/AuthenticationFilter.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.omoknoone.onionhotsayyo.member.dto.MemberDTO;
@@ -82,9 +83,16 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
         String refreshTokenId = authService.successLogin(memberId, refreshToken);
 
         response.addHeader("accessToken", accessToken);
-        
-        /* 설명. refreshToken이 아닌 token의 Id를 전달, refreshToken은 서버만 가지고 있음 */
-        response.addHeader("refreshTokenId", refreshTokenId);
         response.addHeader("memberId", memberId);
+
+        /* 설명. refreshToken이 아닌 token의 Id를 전달, refreshToken은 서버만 가지고 있음 */
+        Cookie cookie = new Cookie("refreshTokenId", refreshTokenId);
+        cookie.setMaxAge(604800);        // 7일
+
+        // HttpOnly Cookie 는 추후에 구현
+//        cookie.setHttpOnly(true);
+//        cookie.setPath("/");
+
+        response.addCookie(cookie);
     }
 }

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/AuthenticationFilter.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/AuthenticationFilter.java
@@ -12,6 +12,7 @@ import org.omoknoone.onionhotsayyo.member.dto.MemberDTO;
 import org.omoknoone.onionhotsayyo.member.service.AuthService;
 import org.omoknoone.onionhotsayyo.member.service.MemberService;
 import org.omoknoone.onionhotsayyo.member.vo.RequestLogin;
+import org.omoknoone.onionhotsayyo.nationality.service.NationalityService;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -26,13 +27,15 @@ import java.util.ArrayList;
 public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
     private final MemberService memberService;
+    private final NationalityService nationalityService;
     private final AuthService authService;
     private final Environment environment;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthenticationFilter(AuthenticationManager authenticationManager, MemberService memberService, AuthService authService, Environment environment, JwtTokenProvider jwtTokenProvider) {
+    public AuthenticationFilter(AuthenticationManager authenticationManager, MemberService memberService, NationalityService nationalityService, AuthService authService, Environment environment, JwtTokenProvider jwtTokenProvider) {
         super(authenticationManager);
         this.memberService = memberService;
+        this.nationalityService = nationalityService;
         this.authService = authService;
         this.environment = environment;
         this.jwtTokenProvider = jwtTokenProvider;
@@ -68,6 +71,7 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
         /* 설명. DB를 다녀와 사용자의 고유 아이디(memberId)를 가져올 예정(Principal 객체(Authentication)에는 없는 값이므로) */
         MemberDTO memberDetails = memberService.getMemberDetailsByMemberId(id);
         String memberId = memberDetails.getMemberId();
+        String language = nationalityService.viewLanguage(memberDetails.getNationalityId());
 //        String roleName = memberDetails.getRoleName();
 
         Claims claims = Jwts.claims().setSubject(memberId);
@@ -84,6 +88,7 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
         response.addHeader("accessToken", accessToken);
         response.addHeader("memberId", memberId);
+        response.addHeader("language", language);
 
         /* 설명. refreshToken이 아닌 token의 Id를 전달, refreshToken은 서버만 가지고 있음 */
         Cookie cookie = new Cookie("refreshTokenId", refreshTokenId);

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/CorsConfig.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/CorsConfig.java
@@ -1,0 +1,30 @@
+package org.omoknoone.onionhotsayyo.member.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("accessToken", "memberId"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/CorsConfig.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/CorsConfig.java
@@ -20,7 +20,7 @@ public class CorsConfig {
         config.setAllowedOrigins(List.of("http://localhost:5173"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
         config.setAllowedHeaders(List.of("*"));
-        config.setExposedHeaders(List.of("accessToken", "memberId"));
+        config.setExposedHeaders(List.of("accessToken", "memberId", "nickname", "language"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/WebSecurity.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/WebSecurity.java
@@ -29,18 +29,20 @@ public class WebSecurity {
     private final Environment environment;
     private final JwtUtil jwtUtil;
     private final JwtTokenProvider jwtTokenProvider;
+    private final CorsConfig corsConfig;
 
     @Autowired
     public WebSecurity(MemberService memberService, AuthService authService,
                        BCryptPasswordEncoder bCryptPasswordEncoder,
                        Environment environment,
-                       JwtUtil jwtUtil, JwtTokenProvider jwtTokenProvider) {
+                       JwtUtil jwtUtil, JwtTokenProvider jwtTokenProvider, CorsConfig corsConfig) {
         this.memberService = memberService;
         this.authService = authService;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.environment = environment;
         this.jwtUtil = jwtUtil;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.corsConfig = corsConfig;
     }
 
     /* 설명. 인가(Authorization)용 메소드 */
@@ -56,6 +58,9 @@ public class WebSecurity {
 
         /* 설명. JWT 로그인 처리를 할 것이므로 csrf는 신경쓸 필요가 없다. */
         http.csrf((csrf) -> csrf.disable());
+
+        http.cors(corsConfig -> corsConfig.getClass());
+
 
         http.authorizeHttpRequests((auth) -> auth
                         .requestMatchers(new AntPathRequestMatcher("/**")).permitAll()

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/WebSecurity.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/security/WebSecurity.java
@@ -3,6 +3,7 @@ package org.omoknoone.onionhotsayyo.member.security;
 import jakarta.servlet.Filter;
 import org.omoknoone.onionhotsayyo.member.service.AuthService;
 import org.omoknoone.onionhotsayyo.member.service.MemberService;
+import org.omoknoone.onionhotsayyo.nationality.service.NationalityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,6 +26,7 @@ public class WebSecurity {
 
     private final MemberService memberService;
     private final AuthService authService;
+    private final NationalityService nationalityService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final Environment environment;
     private final JwtUtil jwtUtil;
@@ -32,12 +34,13 @@ public class WebSecurity {
     private final CorsConfig corsConfig;
 
     @Autowired
-    public WebSecurity(MemberService memberService, AuthService authService,
+    public WebSecurity(MemberService memberService, AuthService authService, NationalityService nationalityService,
                        BCryptPasswordEncoder bCryptPasswordEncoder,
                        Environment environment,
                        JwtUtil jwtUtil, JwtTokenProvider jwtTokenProvider, CorsConfig corsConfig) {
         this.memberService = memberService;
         this.authService = authService;
+        this.nationalityService = nationalityService;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.environment = environment;
         this.jwtUtil = jwtUtil;
@@ -83,7 +86,7 @@ public class WebSecurity {
 
     /* 설명. 인증(Authentication)용 메소드 */
     private Filter getAuthenticationFilter(AuthenticationManager authenticationManager) {
-        return new AuthenticationFilter(authenticationManager, memberService, authService, environment, jwtTokenProvider);
+        return new AuthenticationFilter(authenticationManager, memberService, nationalityService, authService, environment, jwtTokenProvider);
     }
 
 }

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/vo/ResponseMember.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/member/vo/ResponseMember.java
@@ -1,49 +1,17 @@
 package org.omoknoone.onionhotsayyo.member.vo;
 
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
 public class ResponseMember {
     private String memberId;
     private String nickname;
     private String email;
+    private String profile;
+    private String image;
 
-    public ResponseMember() {
-    }
-
-    public ResponseMember(String memberId, String nickname, String email) {
-        this.memberId = memberId;
-        this.nickname = nickname;
-        this.email = email;
-    }
-
-    public String getMemberId() {
-        return memberId;
-    }
-
-    public void setMemberId(String memberId) {
-        this.memberId = memberId;
-    }
-
-    public String getNickname() {
-        return nickname;
-    }
-
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    @Override
-    public String toString() {
-        return "ResponseMember{" +
-                "memberId='" + memberId + '\'' +
-                ", nickname='" + nickname + '\'' +
-                ", email='" + email + '\'' +
-                '}';
-    }
 }

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/nationality/service/NationalityService.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/nationality/service/NationalityService.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface NationalityService {
 
     List<NationalityDTO> viewNationality();
+
+    String viewLanguage(String nationalityId);
 }

--- a/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/nationality/service/NationalityServiceImpl.java
+++ b/OnionHotSayYo/src/main/java/org/omoknoone/onionhotsayyo/nationality/service/NationalityServiceImpl.java
@@ -32,4 +32,12 @@ public class NationalityServiceImpl implements NationalityService {
         List<Nationality> nationalityList = nationalityRepository.findAll();
         return modelMapper.map(nationalityList, new TypeToken<List<NationalityDTO>>() {}.getType());
     }
+
+    @Override
+    public String viewLanguage(String nationalityId) {
+
+        Nationality nationality = nationalityRepository.findById(nationalityId).orElseThrow(IllegalArgumentException::new);
+
+        return nationality.getLanguage();
+    }
 }


### PR DESCRIPTION
### 이 PR이 해결하는 문제
- 로그인 상태 유지
- 라우터 이동 시 토큰 유지

### 변경 내용
- 라우터를 통해 페이지 이동 시 토큰 값과 같이 이동
- vuex를 이용하여 로그인 시 넘어오는 값들 저장